### PR TITLE
Loading/Error template

### DIFF
--- a/Maui.ServerDrivenUI/Abstractions/IServerDrivenVisualElement.cs
+++ b/Maui.ServerDrivenUI/Abstractions/IServerDrivenVisualElement.cs
@@ -2,21 +2,17 @@
 
 public interface IServerDrivenVisualElement
 {
-    public string? ServerKey
-    {
-        get; set;
-    }
+    string? ServerKey { get; set; }
 
-    public UIElementState State
-    {
-        get; set;
-    }
-    public Action OnLoaded
-    {
-        get;
-        set;
-    }
+    UIElementState State { get; set; }
+
+    Action? OnLoaded { get; set; }
+
+    DataTemplate LoadingTemplate { get; set; }
+
+    DataTemplate ErrorTemplate { get; set; }
 
     void OnStateChanged(UIElementState newState);
+
     void OnError(Exception ex);
 }

--- a/Maui.ServerDrivenUI/Views/ServerDrivenContentPage.cs
+++ b/Maui.ServerDrivenUI/Views/ServerDrivenContentPage.cs
@@ -18,6 +18,18 @@ public abstract class ServerDrivenContentPage : ContentPage, IServerDrivenVisual
             typeof(ServerDrivenContentPage),
             UIElementState.None,
             propertyChanged: ServerDrivenVisualElement.OnStatePropertyChanged);
+    
+    public static readonly BindableProperty LoadingTemplateProperty = BindableProperty.Create(
+            nameof(LoadingTemplate),
+            typeof(DataTemplate),
+            typeof(ServerDrivenView),
+            null);
+
+    public static readonly BindableProperty ErrorTemplateProperty = BindableProperty.Create(
+        nameof(ErrorTemplate),
+        typeof(DataTemplate),
+        typeof(ServerDrivenView),
+        null);
 
     #endregion
 
@@ -35,10 +47,22 @@ public abstract class ServerDrivenContentPage : ContentPage, IServerDrivenVisual
         set => SetValue(StateProperty, value);
     }
 
-    public Action OnLoaded
+    public Action? OnLoaded
     {
         get;
         set;
+    }
+
+    public DataTemplate LoadingTemplate
+    {
+        get => (DataTemplate)GetValue(LoadingTemplateProperty);
+        set => SetValue(LoadingTemplateProperty, value);
+    }
+
+    public DataTemplate ErrorTemplate
+    {
+        get => (DataTemplate)GetValue(ErrorTemplateProperty);
+        set => SetValue(ErrorTemplateProperty, value);
     }
 
     #endregion

--- a/Maui.ServerDrivenUI/Views/ServerDrivenView.cs
+++ b/Maui.ServerDrivenUI/Views/ServerDrivenView.cs
@@ -19,6 +19,18 @@ public class ServerDrivenView : ContentView, IServerDrivenVisualElement
             UIElementState.None,
             propertyChanged: ServerDrivenVisualElement.OnStatePropertyChanged);
 
+    public static readonly BindableProperty LoadingTemplateProperty = BindableProperty.Create(
+            nameof(LoadingTemplate),
+            typeof(DataTemplate),
+            typeof(ServerDrivenView),
+            null);
+
+    public static readonly BindableProperty ErrorTemplateProperty = BindableProperty.Create(
+        nameof(ErrorTemplate),
+        typeof(DataTemplate),
+        typeof(ServerDrivenView),
+        null);
+
     #endregion
 
     #region Properties
@@ -33,6 +45,18 @@ public class ServerDrivenView : ContentView, IServerDrivenVisualElement
     {
         get => (UIElementState)GetValue(StateProperty);
         set => SetValue(StateProperty, value);
+    }
+
+    public DataTemplate LoadingTemplate
+    {
+        get => (DataTemplate)GetValue(LoadingTemplateProperty);
+        set => SetValue(LoadingTemplateProperty, value);
+    }
+
+    public DataTemplate ErrorTemplate
+    {
+        get => (DataTemplate)GetValue(ErrorTemplateProperty);
+        set => SetValue(ErrorTemplateProperty, value);
     }
 
     public Action? OnLoaded

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ public static class MauiProgram
 }
 ```
 
-- You can now use the ServerDrivenUI Elements 
+- You can now use the ServerDrivenUI Elements, defining the key that will be used to get the UI from the API
+- You can also define a LoadingTemplate and an ErrorTemplate to be shown while the UI is being fetched from the API
+
+```csharp
 
 ```xaml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -53,7 +56,23 @@ public static class MauiProgram
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
-    <ServerDrivenView x:Name="sduiView" ServerKey="MyView" />
+    <ServerDrivenView x:Name="sduiView" ServerKey="MyView">
+        <ServerDrivenView.ErrorTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Label Text="Unexpected error" />
+                </StackLayout>
+            </DataTemplate>
+        </ServerDrivenView.ErrorTemplate>
+
+        <ServerDrivenView.LoadingTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Label Text="Loading..." />
+                </StackLayout>
+            </DataTemplate>
+        </ServerDrivenView.LoadingTemplate>
+    </ServerDrivenView>
 
 </ContentPage>
 
@@ -67,4 +86,4 @@ We are currently doing a [workaround](https://github.com/felipebaltazar/Maui.Ser
 
 ## Repo Activity
 
-![Alt](https://repobeats.axiom.co/api/embed/e3457a9dc9131c33ca38ceb2203bfffa67864080.svg "Repobeats analytics image")
+![Alt](https://repobeats.axiom.co/api/embed/e3457a9dc9131c33ca38ceb2203bfffa67864080.svg "Repo activity analytics image")

--- a/samples/Maui.ServerDrivenUI.Sample/MainPage.xaml
+++ b/samples/Maui.ServerDrivenUI.Sample/MainPage.xaml
@@ -4,6 +4,22 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
-    <ServerDrivenView x:Name="sduiView" ServerKey="MyView" />
+    <ServerDrivenView x:Name="sduiView" ServerKey="MyView">
+        <ServerDrivenView.ErrorTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Label Text="Unexpected error" />
+                </StackLayout>
+            </DataTemplate>
+        </ServerDrivenView.ErrorTemplate>
+
+        <ServerDrivenView.LoadingTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Label Text="Loading..." />
+                </StackLayout>
+            </DataTemplate>
+        </ServerDrivenView.LoadingTemplate>
+    </ServerDrivenView>
 
 </ContentPage>

--- a/samples/Maui.ServerDrivenUI.Sample/ViewModelBase.cs
+++ b/samples/Maui.ServerDrivenUI.Sample/ViewModelBase.cs
@@ -11,7 +11,6 @@ public abstract class ViewModelBase : INotifyPropertyChanged
 
     protected void Set<T>(ref T field, T value, string propertyName)
     {
-
         if (!EqualityComparer<T>.Default.Equals(field, value))
         {
             field = value;


### PR DESCRIPTION
### Overview

Created the possibility to define `LoadingTemplate` and `ErrorTemplate` to the `ServerDrivenContentPage` and `ServerDrivenContentView`

### Issues Resolved

- fixes #4 
- fixes #3 

### API Changes
 - Created `IServerDrivenVisualElement.LoadingTemplate` ✨
 - Created `IServerDrivenVisualElement.ErrorTemplate` ✨

### Platforms Affected

- All

### Behavioral Changes
None

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard