### PR TITLE
Include error tracking

### DIFF
--- a/Maui.ServerDrivenUI/AppBuilderExtensions.cs
+++ b/Maui.ServerDrivenUI/AppBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using EasyCaching.LiteDB;
 using Maui.ServerDrivenUI.Models;
 using Maui.ServerDrivenUI.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.LifecycleEvents;
 
 namespace Maui.ServerDrivenUI;
@@ -48,8 +49,22 @@ public static class AppBuilderExtensions
 
     private static bool InitServerDrivenUIService()
     {
-        var service = ServiceProviderHelper.ServiceProvider!.GetService<IServerDrivenUIService>();
-        _ = Task.Run(service!.FetchAsync);
+        var serviceProvider = ServiceProviderHelper.ServiceProvider!;
+        var service = serviceProvider.GetService<IServerDrivenUIService>();
+
+        _ = Task.Run(async () => 
+        {
+            try
+            {
+                await service!.FetchAsync();
+            }
+            catch (Exception ex)
+            {
+
+                serviceProvider.GetService<ILogger>()?
+                               .LogError(ex, "Error fetching server driven UI");
+            }
+        });
 
         return false;
     }

--- a/Maui.ServerDrivenUI/Services/XamlConverterService.cs
+++ b/Maui.ServerDrivenUI/Services/XamlConverterService.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/Maui.ServerDrivenUI/Views/ServerDrivenView.cs
+++ b/Maui.ServerDrivenUI/Views/ServerDrivenView.cs
@@ -65,6 +65,12 @@ public class ServerDrivenView : ContentView, IServerDrivenVisualElement
         set;
     }
 
+    public Action<Exception>? OnErrorEvent
+    {
+        get;
+        set;
+    }
+
     #endregion
 
     #region Constructors
@@ -85,6 +91,7 @@ public class ServerDrivenView : ContentView, IServerDrivenVisualElement
 
     public virtual void OnError(Exception ex)
     {
+        OnErrorEvent?.Invoke(ex);
     }
 
     #endregion


### PR DESCRIPTION
### Overview

This PR includes some ways to track errors in ServerDriven UI loading

### Issues Resolved
- none

### API Changes

- AppBuilderExtensions.InitServerDrivenUIService();
- ServerDrivenView.OnErrorEvent

### Platforms Affected

- All

### Behavioral Changes

Now ServerDrivenView have a new Property, `OnErrorEvent`, that allow to track errors during xaml loading
`InitServerDrivenUIService` will catch exceptions from `IServerDrivenUIService.Fetch` and log it to `ILogger`

### Testing Procedure
 

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard